### PR TITLE
Export precompiled templates as ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-var path = require('path'),
-    Filter = require('broccoli-filter'),
-    handlebars = require('handlebars');
+const Filter = require('broccoli-filter');
+const Handlebars = require('handlebars');
 
 module.exports = HandlebarsFilters;
 
@@ -22,8 +21,6 @@ function HandlebarsFilters (tree, options) {
   this.options.extensions = options.extensions || ['hbs', 'handlebars'];
   this.options.targetExtension = options.targetExtension || ['js'];
   this.options.srcDir = options.srcDir || null;
-  this.options.namespace = options.namespace || 'Handlebars.templates';
-  this.prepareNamespace(this.options.namespace);
 
   // Set options necessary for the filter
   filterOptions = {
@@ -37,69 +34,11 @@ function HandlebarsFilters (tree, options) {
 
 HandlebarsFilters.prototype.processString = function (string, srcFile) {
   try {
-    var templateName = this.getTemplateName(srcFile);
-    var precompiled = handlebars.precompile(string, this.options);
-    var output = "";
-    if (typeof this.namespaceCode !== "undefined" && this.namespaceCode !== null) {
-      output = output + this.namespaceCode;
-      this.namespaceCode = null;
-    }
-    output += this.options.namespace + '[\'' + templateName + '\'] = Handlebars.template(' + precompiled + ');';
-    return output;
+    let precompiled = Handlebars.precompile(string, this.options);
+    return `import Handlebars from 'handlebars';
+    const _template = Handlebars.template(${precompiled});
+    export default _template;`;
   } catch (err) {
     console.log(err.message);
   }
-};
-
-/**
- * Set the template name
- * @param  {string} srcFile src file path
- * @return {string} template name
- */
-HandlebarsFilters.prototype.getTemplateName = function (srcFile) {
-    var templateName = srcFile, regexp;
-
-    //Remove templates path
-    if (this.options.srcDir && this.options.srcDir !== '.') {
-      templateName = templateName.replace(this.options.srcDir, '');
-    }
-
-    //Remove / if there is any
-    if (templateName.indexOf('/') === 0) {
-      templateName = templateName.substr(1, templateName.length);
-    }
-
-    //Remove extension
-    var ext = path.extname(templateName);
-    if (this.options.extensions.indexOf(ext.replace('.', '')) >= 0) {
-      regexp = new RegExp(ext + '$');
-      templateName = templateName.replace(regexp, '');
-    }
-
-    return templateName;
-};
-
-/**
- * Prepares the namespace objects.
- *
- * Because this script doesn't know how deep the napespace is and if all the necessary objects for the namespace exists
- * it has to check all and try to add creation of all of those before fist template is compiled and added to the project.
- * @param  {[string]} namespace for example: Some.Namespace.Templates
- */
-HandlebarsFilters.prototype.prepareNamespace = function(namespace) {
-  var namespaceArray = namespace.split('.');
-  var currentNamespace = "";
-  var namespaceCode = "";
-  for (var i = 0; i < namespaceArray.length; i++) {
-    if (i !== 0) {
-      currentNamespace = currentNamespace + ".";
-    }
-    currentNamespace = currentNamespace + namespaceArray[i];
-    if (i === 0) {
-      namespaceCode = "if (typeof "+ currentNamespace + " === 'undefined') { var " + currentNamespace + " = {};}";
-    } else {
-      namespaceCode = namespaceCode + currentNamespace + " = " + currentNamespace + " || {};";
-    }
-  }
-  this.namespaceCode = namespaceCode;
 };


### PR DESCRIPTION
Fork and initial refactor to support exporting precompiled Handlebars templates as [ECMAScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), i.e. ESM

### Sample output format
```js
import Handlebars from 'handlebars';
const _template = Handlebars.template({
  "compiler": [8, ">= 4.3.0"],
  "main": function (container, depth0, helpers, partials, data) {
    return "<div class=\"my-class\"></div>\n";
  },
  "useData": true
});
export default _template;
```